### PR TITLE
fix(sec): change bearer check on onRequest lifecycle instead of preHa…

### DIFF
--- a/src/bearer.ts
+++ b/src/bearer.ts
@@ -2,6 +2,7 @@ import { InsufficientScopeError, InvalidTokenError, OAuthError, ServerError } fr
 import type { BearerAuthMiddlewareOptions } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+
 /**
  * Middleware that requires a valid Bearer token in the Authorization header.
  * This will validate the token with the auth provider and add the resulting auth info to the request object.
@@ -10,7 +11,7 @@ import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 export function addBearerPreHandlerHook (app: FastifyInstance, options: BearerAuthMiddlewareOptions) {
   const { verifier, requiredScopes = [], resourceMetadataUrl } = options;
 
-  app.addHook('preHandler', async (req, reply) => {
+  app.addHook('onRequest', async (req, reply) => {
     try {
       const authInfo = await getAuthInfo(req, verifier, requiredScopes);
       Object.assign(req.raw, { auth: authInfo }); // Ensure raw request also has auth info


### PR DESCRIPTION
Closes #17 

This pull request modifies the `addBearerPreHandlerHook` function to fix a potential security issue in the handling of Bearer token authentication. The most significant change is the replacement of the `preHandler` hook with the `onRequest` hook to ensure authentication occurs earlier in the request lifecycle before parsing the body.

