### PR TITLE
fix: support LTS version of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     ".": "./dist/index.js"
   },
   "engines": {
-    "node": ">= 23.10.0"
+    "node": ">= 22"
   },
   "keywords": [
     "fastify",


### PR DESCRIPTION
Avoid the odd numbered Node versions, they're basically beta previews.

https://nodejs.org/en/about/previous-releases